### PR TITLE
Updated Akka to 2.3.0, not thoroughly tested

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.2.3"
+  lazy val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.3.0"
   
   lazy val ioCore = "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.2"
   lazy val ioFile = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2"

--- a/project/FlowBuild.scala
+++ b/project/FlowBuild.scala
@@ -7,7 +7,7 @@ import NativePackKeys._
 object FlowBuild extends Build {
   val Organization = "com.github.jodersky"
   val ScalaVersion = "2.10.3"
-  val Version = "1.1.0" //version of flow library
+  val Version = "1.2.0" //version of flow library
   val NativeMajorVersion = 2 //major version of native API
   val NativeMinorVersionPosix = 0 //minor version of native posix implementation
   val NativeVersionPosix = NativeMajorVersion + "." + NativeMinorVersionPosix


### PR DESCRIPTION
Hello there!

It seems as if flow does not work correctly on Akka 2.3.0 without being recompiled against this version. 
This change ups the akka-actor dependency version to 2.3.0 as well as the project version to 1.2.0. 

I have not yet tested this thoroughly, but it seems to be working correctly.
I will report back if I notice anything that's off!
