### PR TITLE
Osx fix

### DIFF
--- a/project/FlowBuild.scala
+++ b/project/FlowBuild.scala
@@ -114,7 +114,7 @@ object FlowBuild extends Build {
     val linker = compiler
     val cFlags = Seq("-O2", "-fPIC")
     val linkerFlags = Seq("-dynamiclib")
-    val binary = s"libflow.jnilib"
+    val binary = s"libflow.dylib"
 
     val localBuild = NativeBuild(
       "amd64-macosx",
@@ -156,7 +156,8 @@ object FlowBuild extends Build {
         val linkMappings = Map(
           "x86_64-linux-gnu" -> "amd64-linux",
           "x86-linux-gnu" -> "x86-linux",
-          "arm-linux-gnueabihf" -> "arm-linux"
+          "arm-linux-gnueabihf" -> "arm-linux",
+          "amd64-macosx" -> "x86_64-macosx"
         )
         val ls: Seq[(NativeBuild, File)] = (nativeLink in flow).value.toSeq
         for ((build, binary) <- ls; n <- linkMappings.get(build.name)) yield {


### PR DESCRIPTION
The native build wasn't working on OSX - at least for me on Mavericks, with Java > 1.6 (tried 1.7 and 1.8)
I changed the string used to identify the OS, since it seems that Oracle java uses "mac os x" rather than "macosx". I've also changed the way that the native build finds the machine dependent jni headers, since the paths were hard coded before. Newer version of osx also changed the naming convention of uni libraries - I have updated the native build to reflect that. The new setting uses the same technique as the linux build, and I think it should work across all versions of osx, though I've only actually tried it on Mavericks with Java 1.7 and can't vouch for it working everywhere.

By the way - the documentation for building and installing the native libraries are very confusing for a newcomer to SBT. It simply says "run flow-pack/publishLocal", but this doesn't really mean anything to a newcomer to SBT. Also, when I simply followed the instructions SBT would install a build to the local cache that has a git has included in the version number, which didn't work. The appending of the git hash seems to be due to the "isSnapshot" setting being true, but without knowing SBT very well I couldn't work out how to set the "release" system property which seems to be the requirement for setting "isSnapshot" correctly - I ended up just hacking the build file and hardcoding isSnapshot to false. Some more detailed documentation would be helpful for people like myself who aren't experienced with SBT.
