### PR TITLE
added a Mac makefile. It's crude, but it works.

### DIFF
--- a/flow-native/mac/Makefile
+++ b/flow-native/mac/Makefile
@@ -1,0 +1,12 @@
+# Include common settings
+include ../common.mk
+
+JAVALIB=lib$(NAME)$(MAJOR).dylib
+
+all: $(JAVALIB)
+
+$(JAVALIB): 
+	gcc -dynamiclib -I$(JAVA_HOME)/include/darwin -I$(JAVA_HOME)/include -I../include ../flow_jni.c ../posix/flow.c -o $(JAVALIB) -m64
+
+clean: 
+	-del $(JAVALIB)

--- a/flow-native/mac/Readme
+++ b/flow-native/mac/Readme
@@ -1,0 +1,2 @@
+You should be able to build on OSX by just running make in this directory.
+The libFlow3.dylib file produced will have to be copied manually into the classpath of your project


### PR DESCRIPTION
Hi,
Here's a make file that works for your 2.0 branch on OSX. It's pretty crude, and just hard codes file names, but it works.
I have to say, I really don't like this way of doing things on OSX, and far preferred the previous build using SBT. As far as I know there isn't a way of "installing" the library on OSX, so to use flow in a project you have to build the library with make and then manually copy the resulting library into your project. The previous "Fat" jar file made it much easier to distribute an application - this is going to be quite messy on OSX unless the application writer does something to wrap the library in a jar themselves.
