### PR TITLE
fully initialize termios struct

### DIFF
--- a/flow-native/src/platform/posix/flow.c
+++ b/flow-native/src/platform/posix/flow.c
@@ -54,12 +54,11 @@ int serial_open(
     /* configure new port settings */
     struct termios newtio;
   
-    /* following calls correspond to makeraw() */
-    newtio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-    newtio.c_oflag &= ~OPOST;
-    newtio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-    newtio.c_cflag &= ~(CSIZE | PARENB);
-    newtio.c_cflag |= CREAD;
+    /* initialize serial interface */
+    newtio.c_iflag = 0;
+    newtio.c_oflag = 0;
+    newtio.c_lflag = 0;
+    newtio.c_cflag = CREAD;
   
     /* set speed */
     speed_t bd;


### PR DESCRIPTION
The `newtio` struct was leaking uninitialized bits not cleared by the initializing bitmask.  The stack allocated `struct termios` fields have undefined initial values–not necessarily zero–so they shouldn't be read until set.  Zeroing the fields will prevent non-POSIX bits from slipping through set.

I discovered this when I was unable to read from a UART device.  It appears that on my platform, OS X Yosemite, the `CRTSCTS` control flag was slipping through.

Great library, by the way.  Very clean.  And a terrific model for Scala/JNI projects.  Many thanks.