### PR TITLE
configure.ac: change search paths for JNI headers on OSX

### DIFF
--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -39,8 +39,9 @@ Several steps are involved in producing the native library:
 
 2. Compile
    
-   1. Check availability of dependencies: C compiler and JDK
-   2. Run `./configure && make`
+    1. Check availability of dependencies: C compiler and JDK (1.7 or above)
+    2. Run `./configure && make`.
+       *Note: should you encounter an error about a missing "jni.h" file, try setting the JAVA_HOME environment variable to point to base path of your JDK installation.*
 
 3. Install
 

--- a/flow-native/m4/ax_jni_include_dir.m4
+++ b/flow-native/m4/ax_jni_include_dir.m4
@@ -65,11 +65,8 @@ else
     _JTOPDIR=`echo "$_ACJNI_FOLLOWED" | sed -e 's://*:/:g' -e 's:/[[^/]]*$::'`
 fi
 
-case "$host_os" in
-        darwin*)        _JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-                        _JINC="$_JTOPDIR/Headers";;
-        *)              _JINC="$_JTOPDIR/include";;
-esac
+_JINC="$_JTOPDIR/include"
+
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])
 _AS_ECHO_LOG([_JINC=$_JINC])
 
@@ -93,6 +90,7 @@ osf*)           _JNI_INC_SUBDIRS="alpha";;
 solaris*)       _JNI_INC_SUBDIRS="solaris";;
 mingw*)     _JNI_INC_SUBDIRS="win32";;
 cygwin*)    _JNI_INC_SUBDIRS="win32";;
+darwin*)    _JNI_INC_SUBDIRS="darwin";;
 *)              _JNI_INC_SUBDIRS="genunix";;
 esac
 


### PR DESCRIPTION
Requires JDK 1.7 at least on Mac OS X

fixes #17